### PR TITLE
Adds Query.data/3 to find by data-attribute

### DIFF
--- a/integration_test/cases/query_test.exs
+++ b/integration_test/cases/query_test.exs
@@ -159,6 +159,15 @@ defmodule Wallaby.Integration.QueryTest do
     assert element
   end
 
+  test "queries can find an element by data attribute", %{session: session} do
+    element =
+      session
+      |> Browser.visit("/page_1.html")
+      |> Browser.find(Query.data("role", "a-data-attribute"))
+
+    assert Element.text(element) == "A data attribute"
+  end
+
   test "all returns an empty list if nothing is found", %{session: session} do
     elements =
       session

--- a/integration_test/support/pages/page_1.html
+++ b/integration_test/support/pages/page_1.html
@@ -66,5 +66,7 @@
     </div>
 
     <span an-attribute="an-attribute-value">Span text</span>
+
+    <span data-role="a-data-attribute">A data attribute</span>
   </body>
 </html>

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -156,6 +156,13 @@ defmodule Wallaby.Query do
   end
 
   @doc """
+  Checks if the data attribute is contained anywhere.
+  """
+  def data(name, selector, opts \\ []) do
+    attribute("data-#{name}", selector, opts)
+  end
+
+  @doc """
   Checks if the provided attribute, value pair is contained anywhere.
   """
   def attribute(name, value, opts \\ []) do

--- a/test/wallaby/query/error_message_test.exs
+++ b/test/wallaby/query/error_message_test.exs
@@ -129,6 +129,17 @@ defmodule Wallaby.Query.ErrorMessageTest do
       Expected to find 1, visible element with the attribute 'an-attribute' with value 'an-attribute-value' but 0, visible elements with the attribute were found.
       """
     end
+
+    test "with data attribute queries" do
+      message =
+        Query.data("role", "data-attribute-value")
+        |> ErrorMessage.message(:not_found)
+        |> format
+
+      assert message == format """
+      Expected to find 1, visible element with the attribute 'data-role' with value 'data-attribute-value' but 0, visible elements with the attribute were found.
+      """
+    end
   end
 
   describe "visibility/1" do


### PR DESCRIPTION
This aims to address https://github.com/keathley/wallaby/issues/136

Description
===========

Adds `Query.data/3` to find an element by data-attribute. We make use of the existing `Query.attribute/3` function and simply pass prefix the `name` of the attribute with `data-`.

A couple of notes:

1. Decided for `Query.data` as opposed to something like `Query.data_attribute` but I'm happy to change that if you feel like it'd be more descriptive.

2. Named the first argument passed into `Query.data` as `name`, but I'm happy to change it to something else (like `key`) if that's preferred.

Also, I know it takes a lot to review PRs and maintain repos, so if this doesn't feel like the right way to go, don't worry about closing this. I was just trying to help out here since I've been using Wallaby more lately. Thanks!